### PR TITLE
Improve Print and PrintPtr performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/CloudyKit/fastprinter
 
-go 1.13
+go 1.20

--- a/printer_test.go
+++ b/printer_test.go
@@ -197,3 +197,10 @@ func BenchmarkPrintStringFmt(b *testing.B) {
 		fmt.Fprint(ww, "-------------------------------------------------------------------------------")
 	}
 }
+
+func BenchmarkBasePrintStr(b *testing.B) {
+	const value = "Hello World"
+	for i := 0; i < b.N; i++ {
+		Print(ww, value)
+	}
+}


### PR DESCRIPTION
I was able to cut the execution time of the benchmark from around 18 ns to 11 ns by cutting the use of reflection.

Im not exactly sure when the type switch cases were added to golang, so im not sure about how much the version needs to be bumped